### PR TITLE
support telegrams with more than 1 byte of data

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -13,6 +13,13 @@ from knx import (
 )
 
 
+@coroutine
+def f(output):
+    while True:
+        x = (yield)
+        output.append(x)
+
+
 class KnxTest(TestCase):
     def test_encode_ga(self):
         x = encode_ga('0/1/14')
@@ -26,22 +33,58 @@ class KnxTest(TestCase):
         d = encode_data('HHB', (27, 1, 0))
         self.assertEqual(b'\x00\x05\x00\x1b\x00\x01\x00', d)
 
-    def test_telegram_decoder(self):
+
+    def decode(self, b):
         output = []
+        decoder = telegram_decoder(f(output))
+        decoder.send(b)
+        return output
 
-        @coroutine
-        def f():
-            while True:
-                x = (yield)
-                output.append(x)
-        decoder = telegram_decoder(f())
-        decoder.send(b"\x00\x08\x00'\x11\x08\x00\x14\x00\x81")
+    def test_telegram_decoder_receiving_single_bytes(self):
+        output = []
+        decoder = telegram_decoder(f(output))
+        decoder.send(b'\x00')
+        decoder.send(b'\x08')
+        decoder.send(b'\x00')
+        decoder.send(b'\x27')
+        decoder.send(b'\x11')
+        decoder.send(b'\xFE')
+        decoder.send(b'\x00')
+        decoder.send(b'\x07')
+        decoder.send(b'\x00')
+        decoder.send(b'\x83')
 
+        self.assertEqual(1, len(output))
+        decoded = output[0]
+        self.assertEqual(decoded.src, '1.1.254')
+        self.assertEqual(decoded.dst, '0/0/7')
+        self.assertEqual(decoded.value, 3)
+
+    def test_telegram_decoder_0(self):
+        output = self.decode(b"\x00\x08\x00'\x11\x08\x00\x14\x00\x81")
         self.assertEqual(1, len(output))
         decoded = output[0]
         self.assertEqual(decoded.src, '1.1.8')
         self.assertEqual(decoded.dst, '0/0/20')
-        self.assertEqual(decoded.value, '1')
+        self.assertEqual(decoded.value, 1)
+
+    def test_telegram_decoder_1(self):
+        output = self.decode(b'\x00\x08\x00\x27\x11\xFE\x00\x07\x00\x83')
+
+        self.assertEqual(1, len(output))
+        decoded = output[0]
+        self.assertEqual(decoded.src, '1.1.254')
+        self.assertEqual(decoded.dst, '0/0/7')
+        self.assertEqual(decoded.value, 3)
+
+    def test_telegram_decoder_2(self):
+        output = self.decode(b'\x00\x0B\x00\x27\x11\xFE\x00\x07\x00\x80\x03\xA3\x03')
+
+        self.assertEqual(1, len(output))
+        decoded = output[0]
+        self.assertEqual(decoded.src, '1.1.254')
+        self.assertEqual(decoded.dst, '0/0/7')
+        self.assertEqual(decoded.value, b'\x03\xA3\x03')
 
 
 


### PR DESCRIPTION
The value of Telegrams might now contain the raw data of the binary telegram
if the data contained more than 1 byte.

In addition "read requests" will now have a value of -1 instead of ?
